### PR TITLE
Set xml as standard request format

### DIFF
--- a/lib/billboard-api/remote_resource.rb
+++ b/lib/billboard-api/remote_resource.rb
@@ -2,5 +2,8 @@ module BillboardApi
   # Common superclass to all ActiveResources in Billboard.
   class RemoteResource < ActiveResource::Base
     self.site = BillboardApi::Config.instance.url
+    #For Rails >= 3.1 the default request format has been changed from xml to json
+    #Setting it manually ensures that billboard is compatible with all Rails versions in client
+    self.format = :xml
   end
 end


### PR DESCRIPTION
The default active resource request format for Rails 3.1 and higher has changed from xml to json. But Billboard uses xml.
